### PR TITLE
URL validation, improve macOS testing and testing guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bin
 .kitchen.local.yml
 .coverage
 .kitchen/
+.idea/

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,17 +30,25 @@ platforms:
     provisioner:
       require_chef_omnibus: 12.20.3
 
-# example prive boxes
-# add a new section, rename your box, or this file
+# The following platforms are private boxes and are not available from the vagrant box repository
+# Follow instructions provided in TESTING.md to create a box
+
+# To a use a private box:
+# 1. Create a box. To do so, follow the instructions in TESTING.md
+# 2. Once you've added the vagrant box, modify this file to use it
+# 3. In the 'suites' section of this file, list your box name(s) under 'includes' for the corresponding platform
+# 4. Confirm your box shows up when running `vagrant box list` and `kitchen list` when in this cookbook directory
+
   - name: osx109-desktop
     driver_config:
-      box: osx109-desktop #private
+      box: osx109-desktop
     provisioner:
       require_chef_omnibus: 13.0.118
 
   - name: osx1010
     driver:
       box: osx1010
+      username: <%= ENV['BOX_USERNAME'] %>
     provisioner:
       require_chef_omnibus: 13.0.118
 
@@ -48,29 +56,28 @@ platforms:
     driver_config:
       guest: windows
       communicator: 'winrm'
-      box: win10x64-enterprise #private
+      box: win10x64-enterprise
     provisioner:
       require_chef_omnibus: 12.20.3
 
-  - name: windows_2012_r2
+  - name: windows-2012-r2
     driver_config:
       guest: windows
       communicator: 'winrm'
-      box: windows_2012_r2 #private
+      box: windows-2012-r2
     provisioner:
       require_chef_omnibus: 13.0.118
 
-
-# list your box names under 'includes' for corresponding platform
 suites:
   - name: windows-basic
     run_list:
       - recipe[windows-basic::default]
     includes:
       - windows10
-      - windows_2012_r2
+      - windows-2012-r2
     attributes:
         vsts_agent_test:
+            username: <%= ENV['BOX_USERNAME'] %>
             vsts_url: <%= ENV['VSTS_URL'] %>
             vsts_pool: <%= ENV['VSTS_POOL'] %>
             vsts_token: <%= ENV['VSTS_TOKEN'] %>
@@ -83,6 +90,7 @@ suites:
       - ubuntu1604
     attributes:
         vsts_agent_test:
+            username: <%= ENV['BOX_USERNAME'] %>
             vsts_url: <%= ENV['VSTS_URL'] %>
             vsts_pool: <%= ENV['VSTS_POOL'] %>
             vsts_token: <%= ENV['VSTS_TOKEN'] %>
@@ -96,6 +104,8 @@ suites:
 
     attributes:
         vsts_agent_test:
+            username: <%= ENV['BOX_USERNAME'] %>
             vsts_url: <%= ENV['VSTS_URL'] %>
             vsts_pool: <%= ENV['VSTS_POOL'] %>
             vsts_token: <%= ENV['VSTS_TOKEN'] %>
+

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,10 +30,17 @@ platforms:
     provisioner:
       require_chef_omnibus: 12.20.3
 
-# private boxes
+# example prive boxes
+# add a new section, rename your box, or this file
   - name: osx109-desktop
     driver_config:
       box: osx109-desktop #private
+    provisioner:
+      require_chef_omnibus: 13.0.118
+
+  - name: osx1010
+    driver:
+      box: osx1010
     provisioner:
       require_chef_omnibus: 13.0.118
 
@@ -45,18 +52,29 @@ platforms:
     provisioner:
       require_chef_omnibus: 12.20.3
 
+  - name: windows_2012_r2
+    driver_config:
+      guest: windows
+      communicator: 'winrm'
+      box: windows_2012_r2 #private
+    provisioner:
+      require_chef_omnibus: 13.0.118
+
+
+# list your box names under 'includes' for corresponding platform
 suites:
   - name: windows-basic
     run_list:
       - recipe[windows-basic::default]
     includes:
       - windows10
+      - windows_2012_r2
     attributes:
         vsts_agent_test:
             vsts_url: <%= ENV['VSTS_URL'] %>
             vsts_pool: <%= ENV['VSTS_POOL'] %>
             vsts_token: <%= ENV['VSTS_TOKEN'] %>
-            
+
   - name: debian-basic
     run_list:
       - recipe[debian-basic::default]
@@ -74,6 +92,7 @@ suites:
       - recipe[osx-basic::default]
     includes:
       - osx109-desktop
+      - osx1010
 
     attributes:
         vsts_agent_test:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,11 @@
 LineLength:
   Max: 300
 
-Layout/AlignParameters:
+Style/AlignParameters:
   Exclude:
     - '**/metadata.rb'
 
-Layout/SpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Exclude:
     - '**/metadata.rb'
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,18 +1,13 @@
 LineLength:
   Max: 300
 
-Style/AlignParameters:
+Layout/AlignParameters:
   Exclude:
     - '**/metadata.rb'
 
-Style/SpaceBeforeFirstArg:
+Layout/SpaceBeforeFirstArg:
   Exclude:
     - '**/metadata.rb'
-
-HashSyntax:
-  EnforcedStyle: hash_rockets
-  Exclude:
-    - '**/Berksfile'
 
 Metrics/MethodLength:
   Max: 30

--- a/Berksfile
+++ b/Berksfile
@@ -5,7 +5,7 @@ cookbook 'ark', git: 'git://github.com/ivadim/ark.git'
 metadata
 
 group :integration do
-  cookbook 'debian-basic', :path => './test/cookbooks/debian-basic'
-  cookbook 'windows-basic', :path => './test/cookbooks/windows-basic'
-  cookbook 'osx-basic', :path => './test/cookbooks/osx-basic'
+  cookbook 'debian-basic', path: './test/cookbooks/debian-basic'
+  cookbook 'windows-basic', path: './test/cookbooks/windows-basic'
+  cookbook 'osx-basic', path: './test/cookbooks/osx-basic'
 end

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,6 @@ One of the easiest ways to contribute is to participate in discussions and discu
 Please start a discussion on the [issue tracker](https://github.com/Microsoft/vsts-agent-cookbook/issues).
 
 ## Contributing code and content
-Get familiar with github pull requests https://help.github.com/articles/using-pull-requests/
+Get familiar with GitHub pull requests https://help.github.com/articles/using-pull-requests/
 
 You will need to sign a [Contributor License Agreement](https://cla2.dotnetfoundation.org/) before submitting your pull request.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The following platforms are tested and supported:
 - Debian 8 x64 (Jessie)
 - Ubuntu 16.04
 - Windows 10
+- Windows Server 2012 R2
 - OS X 10.10.5
 - OS X 10.11.4
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ The following platforms are tested and supported:
 - Debian 8 x64 (Jessie)
 - Ubuntu 16.04
 - Windows 10
-- Mac OS X 10.11.4 
+- OS X 10.10.5
+- OS X 10.11.4
 
 Attributes
 ----------
 * `node['vsts_agent']['binary']['version']` - set version of package to install
-* `node['vsts_agent']['prerequisites']['osx']['install']` - control osx dependencies installation. Default true
+* `node['vsts_agent']['prerequisites']['osx']['install']` - control macos dependencies installation. Default true
 * `node['vsts_agent']['prerequisites']['debian']['install']` - control debian dependencies installation. Default true
 
 Resource/Provider
@@ -39,8 +40,8 @@ This resource installs and configures the vsts build and release agent
 - `agent_name`: Name attribute. The name of the vsts agent
 - `version`: an agent version to install. Default version from an attribute
 - `install_dir`: A target directory to install the vsts agent
-- `path`: Overwrite system PATH environment variable values. Linux and Mac OS X only
-- `env`: Additional environment variables. Linux and Mac OS X only 
+- `path`: Overwrite system PATH environment variable values. Linux and macOS only
+- `env`: Additional environment variables. Linux and macOS only
 - `user`: Set a local user to run the vsts agent
 - `group`: Set a local group to run the vsts agent
 - `runasservice`: run agent as a service. Default 'true'

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ namespace :style do
 end
 
 desc 'Run all style checks'
-task :style => ['style:chef', 'style:ruby']
+task style: ['style:chef', 'style:ruby']
 
 desc 'Run ChefSpec'
 RSpec::Core::RakeTask.new(:spec)
@@ -29,8 +29,8 @@ task :supermarket do
   exec 'chef exec knife supermarket share vsts_agent Other -o .. -k supermarket.pem -u vsts_agent_cookbook'
 end
 
-task :default => ['style', 'kitchen:linux']
+task default: ['style', 'kitchen:linux']
 
-task :travis => ['style']
+task travis: ['style']
 
-task :release => ['supermarket']
+task release: ['supermarket']

--- a/TESTING.md
+++ b/TESTING.md
@@ -39,6 +39,11 @@ export VSTS_USER=username
 export VSTS_TOKEN=my_secret_token_from_vsts
 ```
 
+If the username of the box you're testing against happens to differ from "vagrant":
+```
+export BOX_USERNAME=vagrant_box_username
+```
+
 #### Executing the tests
 The `kitchen test` instance states are in order: destroy, create, converge, setup, verify, destroy. `kitchen test` changes the state of one or more instances to destroyed, then executes the actions for each state up to destroy. At any sign of failure, executing the actions stops and the instance is left in the last successful execution state.
 ```
@@ -51,7 +56,7 @@ kitchen test VAGRANT_BOX_NAME
 `$ kitchen test ubuntu1604`
 
 
-:small_red_triangle: The Windows and Mac boxes must be [built](#guides-for-building-mac-and-windows-boxes) prior to testing. Once built, you'll need to modify the `.kitchen.yml` file. To find out list of available boxes and their names, simply execute `vagrant box list`. See the [Chef documentation](https://docs.chef.io/config_yml_kitchen.html) for how to modify it for your boxes.
+:small_red_triangle: The Windows and Mac boxes must be [built](#guides-for-building-mac-and-windows-boxes) prior to testing. Once built, you'll need to modify the `.kitchen.yml` file. To find out list of available boxes and their names, simply execute `vagrant box list`. See the [Chef documentation](https://docs.chef.io/config_yml_kitchen.html) or comments in `.kitchen.yml` for how to modify it for your boxes.
 
 #### Style Testing
 Ruby and Chef ([Foodcritic](http://www.foodcritic.io/)) style checks can be performed by running:

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,12 +1,60 @@
 # Testing Documentation
 
 ## Prerequisites
-VSTS Build Agent cookbook requires ChefDK installation. ChefDK can be downloaded at https://downloads.chef.io/chef-dk/
+VSTS Build Agent cookbook requires ChefDK installation - download it [here](https://downloads.chef.io/chef-dk/).
 
 Integration testing uses Hashicorp's [Vagrant](https://www.vagrantup.com/downloads.html) and Oracle's [Virtualbox](https://www.virtualbox.org/wiki/Downloads), which must be installed first.
 
-## Style Testing
-Ruby and Chef([Foodcritic](http://www.foodcritic.io/)) style checks can be performed by running:
+You'll also need the following from VSTS:
+- Username
+- [Account URL](https://www.visualstudio.com/en-us/get-started/setup/sign-up-for-visual-studio-online)
+- [Personal access token](http://roadtoalm.com/2015/07/22/using-personal-access-tokens-to-access-visual-studio-online/)
+- [Build pool name](http://blog.devmatter.com/understanding-pools-and-queues-in-vso/)
+
+### Integration testing using boxes and Virtualbox
+Integration tests are orchestrated by [test-kitchen](https://github.com/test-kitchen/test-kitchen).
+Although Linux boxes are freely available from Vagrant's repository, for Mac and Windows, you'll need to build your own using Hashicorp's [Packer](https://www.packer.io/).
+
+#### Guides for building Mac and Windows boxes
+- [Mac VM templates for Packer and VeeWee](https://github.com/timsutton/osx-vm-templates)
+- [Windows Packer templates](https://github.com/joefitzgerald/packer-windows)
+- [Boxcutter](https://github.com/boxcutter) (All platforms)
+
+
+### Running the tests
+#### Set environment variables
+
+Windows:
+```
+set VSTS_URL='https://account.visualstudio.com'
+set VSTS_POOL=default
+set VSTS_USER=username
+set VSTS_TOKEN=my_secret_token_from_vsts
+```
+Linux / Mac:
+```
+export VSTS_URL='https://account.visualstudio.com'
+export VSTS_POOL=default
+export VSTS_USER=username
+export VSTS_TOKEN=my_secret_token_from_vsts
+```
+
+#### Executing the tests
+The `kitchen test` instance states are in order: destroy, create, converge, setup, verify, destroy. `kitchen test` changes the state of one or more instances to destroyed, then executes the actions for each state up to destroy. At any sign of failure, executing the actions stops and the instance is left in the last successful execution state.
+```
+kitchen test VAGRANT_BOX_NAME
+```
+
+#### Examples:
+`$ kitchen test osx1010`  
+`$ kitchen test windows_2012_r2`  
+`$ kitchen test ubuntu1604`
+
+
+:small_red_triangle: The Windows and Mac boxes must be [built](#guides-for-building-mac-and-windows-boxes) prior to testing. Once built, you'll need to modify the `.kitchen.yml` file. To find out list of available boxes and their names, simply execute `vagrant box list`. See the [Chef documentation](https://docs.chef.io/config_yml_kitchen.html) for how to modify it for your boxes.
+
+#### Style Testing
+Ruby and Chef ([Foodcritic](http://www.foodcritic.io/)) style checks can be performed by running:
 ```
 chef exec rake style
 ```
@@ -14,37 +62,3 @@ or
 ```
 rake style
 ```
-
-## Integration Testing
-Integration tests are orchestrated by [test-kitchen](https://github.com/test-kitchen/test-kitchen). Currently kitchen.yml contains mix of public(linux) and private boxes(Windows and MacOSX). Windows and MacOSX boxes can be built locally with help of Hashicorp's [packer](https://www.packer.io/) tool.
-:small_red_triangle:NOTE: To use MacOSX boxes you need an Apple-branded computer.
-
-Additionally you need [vsts account url](https://www.visualstudio.com/en-us/get-started/setup/sign-up-for-visual-studio-online), username, [personal access token](http://roadtoalm.com/2015/07/22/using-personal-access-tokens-to-access-visual-studio-online/) and [pool name](http://blog.devmatter.com/understanding-pools-and-queues-in-vso/).
-
-Set environment variables
-
-on windows:
-```
-set VSTS_URL=account.visualstudio.com
-set VSTS_POOL=default
-set VSTS_USER=username
-set VSTS_TOKEN=my_secret_token_from_vsts
-```
-on linux or macosx:
-```
-export VSTS_URL=account.visualstudio.com
-export VSTS_POOL=default
-export VSTS_USER=username
-export VSTS_TOKEN=my_secret_token_from_vsts
-```
-
-To run test against specific platform run:
-```
-kitchen verify PLATFORM
-```
-
-Available platforms:
-* debian8 (public)
-* ubuntu1604 (public)
-* osx109-desktop (private)
-* windows10 (private)

--- a/TESTING.md
+++ b/TESTING.md
@@ -39,9 +39,9 @@ export VSTS_USER=username
 export VSTS_TOKEN=my_secret_token_from_vsts
 ```
 
-If the username of the box you're testing against happens to differ from "vagrant":
+If the username of the box you're testing differs from standard "vagrant":
 ```
-export BOX_USERNAME=vagrant_box_username
+export BOX_USERNAME=username
 ```
 
 #### Executing the tests
@@ -59,11 +59,9 @@ kitchen test VAGRANT_BOX_NAME
 :small_red_triangle: The Windows and Mac boxes must be [built](#guides-for-building-mac-and-windows-boxes) prior to testing. Once built, you'll need to modify the `.kitchen.yml` file. To find out list of available boxes and their names, simply execute `vagrant box list`. See the [Chef documentation](https://docs.chef.io/config_yml_kitchen.html) or comments in `.kitchen.yml` for how to modify it for your boxes.
 
 #### Style Testing
-Ruby and Chef ([Foodcritic](http://www.foodcritic.io/)) style checks can be performed by running:
-```
-chef exec rake style
-```
-or
-```
-rake style
-```
+Several style checks can be performed by running any of the following:
+
+`$ chef exec rake style`  
+`$ rake style`  
+`$ foodcritic .`  
+`$ rubocop .`  

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,8 +17,6 @@ when 'mac_os_x', 'mac_os_x_server'
 end
 
 default['vsts_agent']['prerequisites']['osx']['install'] = true
-default['vsts_agent']['prerequisites']['osx']['openssl']['url'] = 'https://www.openssl.org/source/openssl-1.0.2h.tar.gz'
-default['vsts_agent']['prerequisites']['osx']['openssl']['version'] = '1.0.2h'
 
 default['vsts_agent']['prerequisites']['debian']['install'] = true
 default['vsts_agent']['prerequisites']['debian']['libicu52']['url'] = 'http://security.ubuntu.com/ubuntu/pool/main/i/icu/libicu52_52.1-8ubuntu0.2_amd64.deb'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,5 @@ when 'mac_os_x', 'mac_os_x_server'
 end
 
 default['vsts_agent']['prerequisites']['osx']['install'] = true
-
 default['vsts_agent']['prerequisites']['debian']['install'] = true
 default['vsts_agent']['prerequisites']['debian']['libicu52']['url'] = 'http://security.ubuntu.com/ubuntu/pool/main/i/icu/libicu52_52.1-8ubuntu0.2_amd64.deb'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -6,7 +6,7 @@ module VSTS
 
       require 'json'
 
-      VARS_TO_SAVE = %w[install_dir user group].freeze
+      VARS_TO_SAVE = %w(install_dir user group).freeze
 
       def archive_name(resource)
         name = 'vsts_agent'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -44,8 +44,16 @@ module VSTS
         ::File.exist?("#{install_dir}/.agent")
       end
 
+      def valid_url?(resource)
+          vsts_url_pattern = /https:\/\/.*\.visualstudio\.com/
+          if vsts_url_pattern.match?(resource)
+          else
+              raise ArgumentError, "URL validation failed: \"#{resource}\" is not formatted correctly."
+          end
+      end
+
       def save_vars(resource, node)
-        VARS_TO_SAVE.each { |var| node.set['vsts_agent']['agents'][resource.agent_name][var] = resource.send(var) if resource.respond_to?(var.to_sym) }
+        VARS_TO_SAVE.each { |var| node.default['vsts_agent']['agents'][resource.agent_name][var] = resource.send(var) if resource.respond_to?(var.to_sym) }
         node.save
       end
 
@@ -83,7 +91,7 @@ module VSTS
       end
 
       def remove_current_state(resource, node)
-        node.set['vsts_agent']['agents'][resource.agent_name] = {}
+        node.default['vsts_agent']['agents'][resource.agent_name] = {}
         node.save
       end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -6,7 +6,7 @@ module VSTS
 
       require 'json'
 
-      VARS_TO_SAVE = %w(install_dir user group).freeze
+      VARS_TO_SAVE = %w[install_dir user group].freeze
 
       def archive_name(resource)
         name = 'vsts_agent'
@@ -16,8 +16,7 @@ module VSTS
 
       def download_url(version, node)
         url = node['vsts_agent']['binary']['url']
-        url = url.gsub '%s', version
-        url
+        url.gsub '%s', version
       end
 
       def windows?
@@ -44,12 +43,9 @@ module VSTS
         ::File.exist?("#{install_dir}/.agent")
       end
 
-      def valid_url?(resource)
-          vsts_url_pattern = /https:\/\/.*\.visualstudio\.com/
-          if vsts_url_pattern.match?(resource)
-          else
-              raise ArgumentError, "URL validation failed: \"#{resource}\" is not formatted correctly."
-          end
+      def valid_vsts_url?(url)
+        vsts_url_pattern = %r{https:\/\/.*\.visualstudio\.com}
+        vsts_url_pattern.match(url)
       end
 
       def save_vars(resource, node)
@@ -72,7 +68,7 @@ module VSTS
       end
 
       def load_data_from_json(resource)
-        f = ::File.read(::File.join(resource.install_dir, '.agent'), :mode => 'r:bom|utf-8').strip
+        f = ::File.read(::File.join(resource.install_dir, '.agent'), mode: 'r:bom|utf-8').strip
         agent = JSON.parse(f)
         resource.vsts_url(agent['serverUrl'])
         resource.vsts_pool(agent['poolName'])
@@ -108,13 +104,13 @@ module VSTS
       def vsagentexec(args = {})
         command = 'Agent.Listener '
         command = './' + command unless windows?
-        args.each { |key, value| command += append_arguments(key, value) + ' ' }
+        args.each { |key, value| command += append_arguments(key.to_s, value.to_s) + ' ' }
         command
       end
 
       def append_arguments(key, value)
         result = ''
-        if key == 'configure' || key == 'remove'
+        if key.include?('configure') || key.include?('remove')
           result += key
         else
           result += "--#{key}"

--- a/libraries/service.rb
+++ b/libraries/service.rb
@@ -14,10 +14,10 @@ class Chef
 
       default_action :enable
 
-      attribute :name, :kind_of => String, :name_attribute => true
-      attribute :install_dir, :kind_of => String
-      attribute :user, :kind_of => String
-      attribute :group, :kind_of => String
+      attribute :name, kind_of: String, name_attribute: true
+      attribute :install_dir, kind_of: String
+      attribute :user, kind_of: String
+      attribute :group, kind_of: String
     end
   end
 end
@@ -94,13 +94,13 @@ class Chef
         elsif operation == 'disable'
           operation = 'uninstall'
         end
-        envvars = { 'HOME' => "/Users/#{new_resource.user}" }
+        envvars = { HOME: "/Users/#{new_resource.user}" }
         execute "Run action '#{operation}' on service '#{new_resource.name}'" do
           cwd new_resource.install_dir
           command "./svc.sh #{operation}"
           user new_resource.user if osx?
           group new_resource.group if osx?
-          environment envvars if osx?
+          environment envvars.to_s if osx?
           action :run
           retries 3
         end

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ issues_url       'https://github.com/Microsoft/vsts-agent-cookbook/issues' if re
 chef_version     '>= 12.4' if respond_to?(:chef_version)
 version          '1.2.0'
 
-%w[ubuntu debian mac_os_x mac_os_x_server windows].each do |operating_system|
+%w(ubuntu debian mac_os_x mac_os_x_server windows).each do |operating_system|
   supports operating_system
 end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,8 +9,8 @@ issues_url       'https://github.com/Microsoft/vsts-agent-cookbook/issues' if re
 chef_version     '>= 12.4' if respond_to?(:chef_version)
 version          '1.2.0'
 
-%w(ubuntu debian mac_os_x mac_os_x_server windows).each do |os|
-  supports os
+%w[ubuntu debian mac_os_x mac_os_x_server windows].each do |operating_system|
+  supports operating_system
 end
 
 depends 'homebrew'

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,6 +12,7 @@ version          '1.2.0'
   supports os
 end
 
+depends 'homebrew'
 depends 'windows'
 depends 'ark'
 depends 'seven_zip', '~> 2.0.0'

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -31,6 +31,7 @@ action :install do
   end
 
   service_id = "vsts_agent_service[#{new_resource.agent_name}]"
+  valid_url? new_resource.vsts_url
 
   if @current_resource.exists
     Chef::Log.info "'#{new_resource.agent_name}' agent '#{current_resource.version}' already exists - nothing to do"

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -31,7 +31,8 @@ action :install do
   end
 
   service_id = "vsts_agent_service[#{new_resource.agent_name}]"
-  valid_url? new_resource.vsts_url
+
+  raise ArgumentError, "URL validation failed: \"#{new_resource.vsts_url}\" is not formatted correctly." unless valid_vsts_url? new_resource.vsts_url
 
   if @current_resource.exists
     Chef::Log.info "'#{new_resource.agent_name}' agent '#{current_resource.version}' already exists - nothing to do"
@@ -60,7 +61,7 @@ action :install do
 
       directory new_resource.install_dir do
         recursive true
-        rights :full_control, new_resource.user, :applies_to_children => true if windows?
+        rights :full_control, new_resource.user, applies_to_children: true if windows?
         user new_resource.user
         group new_resource.group
         mode '0755'
@@ -74,22 +75,22 @@ action :install do
       end
 
       args = {
-        'configure' => nil,
-        'unattended' => nil,
-        'replace' => nil,
-        'url' => new_resource.vsts_url,
-        'pool' => new_resource.vsts_pool,
-        'agent' => new_resource.agent_name,
-        'work' => new_resource.work_folder
+        configure: nil,
+        unattended: nil,
+        replace: nil,
+        url: new_resource.vsts_url,
+        pool: new_resource.vsts_pool,
+        agent: new_resource.agent_name,
+        work: new_resource.work_folder
       }
 
       if new_resource.runasservice
-        args['runasservice'] = nil
+        args[:runasservice] = nil
         if windows?
-          args['windowslogonaccount'] = new_resource.windowslogonaccount
+          args[:windowslogonaccount] = new_resource.windowslogonaccount
         end
         if windows? && new_resource.windowslogonpassword
-          args['windowslogonpassword'] = new_resource.windowslogonpassword
+          args[:windowslogonaccount] = new_resource.windowslogonpassword
         end
       end
 
@@ -133,7 +134,7 @@ action :install do
 
   template "#{new_resource.install_dir}/.path" do
     source 'path.erb'
-    variables(:path => new_resource.path)
+    variables(path: new_resource.path)
     user new_resource.user
     group new_resource.group
     mode '0755'
@@ -145,7 +146,7 @@ action :install do
 
   template "#{new_resource.install_dir}/.env" do
     source 'env.erb'
-    variables(:env => new_resource.env)
+    variables(env: new_resource.env)
     user new_resource.user
     group new_resource.group
     mode '0755'
@@ -201,8 +202,8 @@ def remove_agent(resource)
   end
 
   args = {
-    'remove' => nil,
-    'unattended' => nil
+    remove: nil,
+    unattended: nil
   }
 
   set_auth(args, resource)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,5 +1,3 @@
-include_recipe 'ark::default'
-
 if platform_family?('debian') && node['vsts_agent']['prerequisites']['debian']['install']
   package 'libunwind8'
   package 'libcurl3'
@@ -8,6 +6,7 @@ if platform_family?('debian') && node['vsts_agent']['prerequisites']['debian']['
   end
 
 elsif platform_family?('mac_os_x') || platform_family?('mac_os_x_server') && node['vsts_agent']['prerequisites']['osx']['install']
+
   include_recipe 'homebrew'
 
   package 'openssl' # Reference: https://www.microsoft.com/net/core#macos

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,7 +7,7 @@ if platform_family?('debian') && node['vsts_agent']['prerequisites']['debian']['
     package 'libicu52'
   end
 
-elsif (platform_family?('mac_os_x') || platform_family?('mac_os_x_server'))
+elsif platform_family?('mac_os_x') || platform_family?('mac_os_x_server')
   include_recipe 'homebrew'
 
   package 'openssl' # Reference: https://www.microsoft.com/net/core#macos

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,5 +1,3 @@
-include_recipe 'ark::default'
-
 if platform_family?('debian') && node['vsts_agent']['prerequisites']['debian']['install']
   package 'libunwind8'
   package 'libcurl3'
@@ -7,29 +5,23 @@ if platform_family?('debian') && node['vsts_agent']['prerequisites']['debian']['
     package 'libicu52'
   end
 
-elsif (platform_family?('mac_os_x') || platform_family?('mac_os_x_server')) && node['vsts_agent']['prerequisites']['osx']['install']
-  cpu = node['cpu'] ? node['cpu']['total'].to_i : 2
-  version = node['vsts_agent']['prerequisites']['osx']['openssl']['version']
-  ark 'openssl' do
-    url node['vsts_agent']['prerequisites']['osx']['openssl']['url']
-    backup false
-    path Chef::Config[:file_cache_path]
-    action :put
+elsif (platform_family?('mac_os_x') || platform_family?('mac_os_x_server'))
+  include_recipe 'homebrew'
+
+  package 'openssl' # Reference: https://www.microsoft.com/net/core#macos
+
+  execute 'configure brew-installed openssl' do
+    command 'mkdir -p /usr/local/lib/'
+    action :run
   end
 
-  bash "Make openssl #{version}" do
-    cwd "#{Chef::Config[:file_cache_path]}/openssl"
-    code <<-EOH
-      ./configure shared darwin64-x86_64-cc --prefix=/usr/local/openssl-#{version}
-      make depend
-      make -j #{cpu}
-      make install
-      rm -rf /usr/local/openssl /usr/local/bin/openssl
-      ln -s /usr/local/openssl-#{version} /usr/local/openssl
-      ln -s /usr/local/openssl/bin/openssl /usr/local/bin/openssl
-      mkdir -p /usr/local/lib
-      cp /usr/local/openssl/lib/lib* /usr/local/lib/
-    EOH
-    not_if "/usr/local/bin/openssl version |grep #{version}"
+  execute 'link libcrypto dylib' do
+    command 'ln -sf /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/'
+    action :run
+  end
+
+  execute 'link libssl dylib' do
+    command 'ln -sf /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/'
+    action :run
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,7 +7,7 @@ if platform_family?('debian') && node['vsts_agent']['prerequisites']['debian']['
     package 'libicu52'
   end
 
-elsif platform_family?('mac_os_x') || platform_family?('mac_os_x_server')
+elsif platform_family?('mac_os_x') || platform_family?('mac_os_x_server') && node['vsts_agent']['prerequisites']['osx']['install']
   include_recipe 'homebrew'
 
   package 'openssl' # Reference: https://www.microsoft.com/net/core#macos

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,3 +1,5 @@
+include_recipe 'ark::default'
+
 if platform_family?('debian') && node['vsts_agent']['prerequisites']['debian']['install']
   package 'libunwind8'
   package 'libcurl3'

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -1,29 +1,29 @@
 actions :install, :remove, :restart
 default_action :install
 
-attribute :agent_name, :name_attribute => true
-attribute :install_dir, :kind_of => String
+attribute :agent_name, name_attribute: true
+attribute :install_dir, kind_of: String
 
-attribute :user, :kind_of => String
-attribute :group, :kind_of => String
+attribute :user, kind_of: String
+attribute :group, kind_of: String
 
-attribute :work_folder, :kind_of => String, :default => '_work'
+attribute :work_folder, kind_of: String, default: '_work'
 
-attribute :runasservice, :kind_of => [TrueClass, FalseClass], :default => true
-attribute :windowslogonaccount, :kind_of => String
-attribute :windowslogonpassword, :kind_of => String
+attribute :runasservice, kind_of: [TrueClass, FalseClass], default: true
+attribute :windowslogonaccount, kind_of: String
+attribute :windowslogonpassword, kind_of: String
 
 # environment
-attribute :version, :kind_of => String
-attribute :path, :kind_of => String
-attribute :env, :kind_of => Hash, :default => {}
+attribute :version, kind_of: String
+attribute :path, kind_of: String
+attribute :env, kind_of: Hash, default: {}
 
 # VSTS Access
-attribute :vsts_url, :kind_of => String
-attribute :vsts_pool, :kind_of => String
-attribute :vsts_auth, :kind_of => String, :default => 'PAT'
-attribute :vsts_username, :kind_of => String
-attribute :vsts_password, :kind_of => String
-attribute :vsts_token, :kind_of => String
+attribute :vsts_url, kind_of: String
+attribute :vsts_pool, kind_of: String
+attribute :vsts_auth, kind_of: String, default: 'PAT'
+attribute :vsts_username, kind_of: String
+attribute :vsts_password, kind_of: String
+attribute :vsts_token, kind_of: String
 
 attr_accessor :exists

--- a/test/cookbooks/debian-basic/attributes/default.rb
+++ b/test/cookbooks/debian-basic/attributes/default.rb
@@ -2,3 +2,4 @@
 default['vsts_agent_test']['vsts_url'] = nil
 default['vsts_agent_test']['vsts_pool'] = nil
 default['vsts_agent_test']['vsts_token'] = nil
+default['vsts_agent_test']['username'] = 'vagrant'

--- a/test/cookbooks/debian-basic/recipes/default.rb
+++ b/test/cookbooks/debian-basic/recipes/default.rb
@@ -2,12 +2,12 @@
 include_recipe 'apt::default'
 include_recipe 'build-essential::default'
 
-user 'vagrant' do
+user node['vsts_agent_test']['username'].to_s do
   manage_home true
   comment 'Vagrant user'
-  home '/home/vagrant'
+  home "/home/#{node['vsts_agent_test']['username']}"
   shell '/bin/bash'
-  not_if 'id -u vagrant'
+  not_if "id -u #{node['vsts_agent_test']['username']}"
 end
 
 user 'builder' do
@@ -24,7 +24,7 @@ include_recipe 'vsts_agent::default'
 agent1_name = "#{node['hostname']}_01"
 agent2_name = "#{node['hostname']}_02"
 
-agents_dir = '/home/vagrant/agents'
+agents_dir = "/home/#{node['hostname']}/agents"
 
 # cleanup
 vsts_agent agent1_name do
@@ -40,8 +40,8 @@ end
 # # Agent1
 vsts_agent agent1_name do
   install_dir "#{agents_dir}/#{agent1_name}"
-  user 'vagrant'
-  group 'vagrant'
+  user node['vsts_agent_test']['username']
+  group node['vsts_agent_test']['username']
   vsts_url node['vsts_agent_test']['vsts_url']
   vsts_pool node['vsts_agent_test']['vsts_pool']
   vsts_token node['vsts_agent_test']['vsts_token']
@@ -72,4 +72,9 @@ end
 
 vsts_agent agent2_name do
   action :restart
+end
+
+vsts_agent agent2_name do
+  vsts_token node['vsts_agent_test']['vsts_token']
+  action :remove
 end

--- a/test/cookbooks/osx-basic/attributes/default.rb
+++ b/test/cookbooks/osx-basic/attributes/default.rb
@@ -1,4 +1,7 @@
-# set attributes through test kitchen
+# set vsts attributes through test kitchen
 default['vsts_agent_test']['vsts_url'] = nil
 default['vsts_agent_test']['vsts_pool'] = nil
 default['vsts_agent_test']['vsts_token'] = nil
+
+# adjust username here if box uses something other than vagrant
+default['username'] = 'vagrant'

--- a/test/cookbooks/osx-basic/attributes/default.rb
+++ b/test/cookbooks/osx-basic/attributes/default.rb
@@ -2,6 +2,4 @@
 default['vsts_agent_test']['vsts_url'] = nil
 default['vsts_agent_test']['vsts_pool'] = nil
 default['vsts_agent_test']['vsts_token'] = nil
-
-# adjust username here if box uses something other than vagrant
-default['username'] = 'vagrant'
+default['vsts_agent_test']['username'] = 'vagrant'

--- a/test/cookbooks/osx-basic/recipes/default.rb
+++ b/test/cookbooks/osx-basic/recipes/default.rb
@@ -15,6 +15,11 @@ vsts_agent agent1_name do
   action :remove
 end
 
+vsts_agent agent2_name do
+  vsts_token node['vsts_agent_test']['vsts_token']
+  action :remove
+end
+
 # Agent1
 vsts_agent agent1_name do
   install_dir "#{agents_dir}/#{agent1_name}"
@@ -50,4 +55,9 @@ end
 
 vsts_agent agent2_name do
   action :restart
+end
+
+vsts_agent agent2_name do
+  vsts_token node['vsts_agent_test']['vsts_token']
+  action :remove
 end

--- a/test/cookbooks/osx-basic/recipes/default.rb
+++ b/test/cookbooks/osx-basic/recipes/default.rb
@@ -7,7 +7,7 @@ include_recipe 'vsts_agent::default'
 agent1_name = "osx_#{node['hostname']}_01"
 agent2_name = "osx_#{node['hostname']}_02"
 
-agents_dir = '/Users/vagrant/agents'
+agents_dir = "/Users/#{node['username']}/agents"
 
 # cleanup
 vsts_agent agent1_name do
@@ -18,7 +18,7 @@ end
 # Agent1
 vsts_agent agent1_name do
   install_dir "#{agents_dir}/#{agent1_name}"
-  user 'vagrant'
+  user "#{node['username']}"
   group 'staff'
   vsts_url node['vsts_agent_test']['vsts_url']
   vsts_pool node['vsts_agent_test']['vsts_pool']
@@ -38,7 +38,7 @@ end
 # Agent2
 vsts_agent agent2_name do
   install_dir "#{agents_dir}/#{agent2_name}"
-  user 'vagrant'
+  user "#{node['username']}"
   group 'staff'
   path '/usr/local/bin/:/usr/bin:/opt/bin/'
   env('M2_HOME' => '/opt/maven', 'JAVA_HOME' => '/opt/java')

--- a/test/cookbooks/osx-basic/recipes/default.rb
+++ b/test/cookbooks/osx-basic/recipes/default.rb
@@ -7,7 +7,7 @@ include_recipe 'vsts_agent::default'
 agent1_name = "osx_#{node['hostname']}_01"
 agent2_name = "osx_#{node['hostname']}_02"
 
-agents_dir = "/Users/#{node['username']}/agents"
+agents_dir = "/Users/#{node['vsts_agent_test']['username']}/agents"
 
 # cleanup
 vsts_agent agent1_name do
@@ -18,7 +18,7 @@ end
 # Agent1
 vsts_agent agent1_name do
   install_dir "#{agents_dir}/#{agent1_name}"
-  user "#{node['username']}"
+  user node['vsts_agent_test']['username']
   group 'staff'
   vsts_url node['vsts_agent_test']['vsts_url']
   vsts_pool node['vsts_agent_test']['vsts_pool']
@@ -38,7 +38,7 @@ end
 # Agent2
 vsts_agent agent2_name do
   install_dir "#{agents_dir}/#{agent2_name}"
-  user "#{node['username']}"
+  user node['vsts_agent_test']['username']
   group 'staff'
   path '/usr/local/bin/:/usr/bin:/opt/bin/'
   env('M2_HOME' => '/opt/maven', 'JAVA_HOME' => '/opt/java')

--- a/test/cookbooks/windows-basic/attributes/default.rb
+++ b/test/cookbooks/windows-basic/attributes/default.rb
@@ -2,3 +2,4 @@
 default['vsts_agent_test']['vsts_url'] = nil
 default['vsts_agent_test']['vsts_pool'] = nil
 default['vsts_agent_test']['vsts_token'] = nil
+default['vsts_agent_test']['username'] = 'vagrant'

--- a/test/cookbooks/windows-basic/recipes/default.rb
+++ b/test/cookbooks/windows-basic/recipes/default.rb
@@ -15,9 +15,8 @@ include_recipe 'vsts_agent::default'
 
 agent1_name = "win_#{node['hostname']}_01"
 agent2_name = "win_#{node['hostname']}_02"
-agent3_name = "win_#{node['hostname']}_03"
 
-agents_dir = 'C:\\Users\\vagrant\\agents'
+agents_dir = "C:\\\\Users\\\\#{node['hostname']}\\\\agents"
 
 # cleanup
 vsts_agent agent1_name do
@@ -30,15 +29,10 @@ vsts_agent agent2_name do
   action :remove
 end
 
-vsts_agent agent3_name do
-  vsts_token node['vsts_agent_test']['vsts_token']
-  action :remove
-end
-
 # Agent1
 vsts_agent agent1_name do
   install_dir "#{agents_dir}/#{agent1_name}"
-  user 'vagrant'
+  user node['vsts_agent_test']['username']
   vsts_url node['vsts_agent_test']['vsts_url']
   vsts_pool node['vsts_agent_test']['vsts_pool']
   vsts_token node['vsts_agent_test']['vsts_token']
@@ -71,14 +65,7 @@ vsts_agent agent2_name do
   action :restart
 end
 
-# Agent3
-vsts_agent agent3_name do
-  install_dir "#{agents_dir}/#{agent3_name}"
-  user 'builder'
-  vsts_url node['vsts_agent_test']['vsts_url']
-  vsts_pool node['vsts_agent_test']['vsts_pool']
+vsts_agent agent2_name do
   vsts_token node['vsts_agent_test']['vsts_token']
-  windowslogonaccount 'builder'
-  windowslogonpassword 'Pas$w0r_d'
-  action :install
+  action :remove
 end

--- a/test/cookbooks/windows-basic/recipes/default.rb
+++ b/test/cookbooks/windows-basic/recipes/default.rb
@@ -6,7 +6,7 @@ user 'builder' do
   password 'Pas$w0r_d'
 end
 
-grant_logon_as_service 'vagrant'
+grant_logon_as_service node['vsts_agent_test']['username']
 grant_logon_as_service 'builder'
 
 #### End prepare system ####
@@ -42,8 +42,8 @@ vsts_agent agent1_name do
   vsts_url node['vsts_agent_test']['vsts_url']
   vsts_pool node['vsts_agent_test']['vsts_pool']
   vsts_token node['vsts_agent_test']['vsts_token']
-  windowslogonaccount 'vagrant'
-  windowslogonpassword 'vagrant'
+  windowslogonaccount node['vsts_agent_test']['username']
+  windowslogonpassword node['vsts_agent_test']['username']
   action :install
 end
 


### PR DESCRIPTION
- Add URL validation for VSTS_URL variable
- Update soon-to-be deprecated node attributes from `node.set` to `node.default`
- Use homebrew for installing openssl on macOS
- More detailed and updated testing guide