### PR TITLE
Correctly handle empty values for command line arguments

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -104,7 +104,7 @@ module VSTS
       def vsagentexec(args = {})
         command = 'Agent.Listener '
         command = './' + command unless windows?
-        args.each { |key, value| command += append_arguments(key.to_s, value.to_s) + ' ' }
+        args.each { |key, value| command += append_arguments(key.to_s, value) + ' ' }
         command
       end
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vsts-agent-cookbook/issues/10.

Before this change generated command would look like this:

```
Agent.Listener configure --unattended "" --replace "" --url "https://mycorp.visualstudio.com" --pool "Default" --agent "agent_01" --work "_work" --runasservice "" --windowslogonaccount --auth "PAT" --token "XXXXXXX"
```

With this fix it looks like this again:

```
Agent.Listener configure --unattended --replace --url "https://mycorp.visualstudio.com" --pool "Default" --agent "agent_01" --work "_work" --runasservice --windowslogonaccount --auth "PAT" --token "XXXXXXX"
```

This bug was introduced in this commit: https://github.com/Microsoft/vsts-agent-cookbook/commit/d6c2655e8952d4f645e1fa0c64e307da481ac974#diff-38a4aeddb4e620724d3b85362cb8b939R107