### PR TITLE
Update URLs to the new format

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,12 +1,12 @@
-default['vsts_agent']['binary']['version'] = '2.125.1'
+default['vsts_agent']['binary']['version'] = '2.126.0'
 
 case node['platform_family']
 when 'windows'
-  default['vsts_agent']['binary']['url'] = 'https://github.com/Microsoft/vsts-agent/releases/download/v%s/vsts-agent-win-x64-%s.zip'
+  default['vsts_agent']['binary']['url'] = 'https://vstsagentpackage.azureedge.net/agent/%s/vsts-agent-win-x64-%s.zip'
 when 'debian', 'rhel'
-  default['vsts_agent']['binary']['url'] = 'https://github.com/Microsoft/vsts-agent/releases/download/v%s/vsts-agent-linux-x64-%s.tar.gz'
+  default['vsts_agent']['binary']['url'] = 'https://vstsagentpackage.azureedge.net/agent/%s/vsts-agent-linux-x64-%s.tar.gz'
 when 'mac_os_x', 'mac_os_x_server'
-  default['vsts_agent']['binary']['url'] = 'https://github.com/Microsoft/vsts-agent/releases/download/v%s/vsts-agent-osx-x64-%s.tar.gz'
+  default['vsts_agent']['binary']['url'] = 'https://vstsagentpackage.azureedge.net/agent/%s/vsts-agent-osx-x64-%s.tar.gz'
 end
 
 # applies for debian based distros: ubuntu, debian etc...

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url       'https://github.com/Microsoft/vsts-agent-cookbook' if respond_to?(:source_url)
 issues_url       'https://github.com/Microsoft/vsts-agent-cookbook/issues' if respond_to?(:issues_url)
 chef_version     '>= 12.4' if respond_to?(:chef_version)
-version          '2.0.1'
+version          '2.0.2'
 
 %w(ubuntu debian redhat centos mac_os_x windows).each do |operating_system|
   supports operating_system


### PR DESCRIPTION
VSTS team stopped publish binaries to github. This PR updates urls with a new location. Fixes #19 